### PR TITLE
rm rank and version number features

### DIFF
--- a/data.py
+++ b/data.py
@@ -25,11 +25,6 @@ class DataFields:
     # version numbers
     max_count_versions: int
     min_count_versions: int
-    # Max/Min of rank values,
-    # the difference between
-    # rank values
-    max_rank_values: int
-    min_rank_values: int
     # Max/Min/Average 
     # time difference between
     # DIO/DIS/DAO messages


### PR DESCRIPTION
Removed the following features - 

1. Max/Min of version numbers, the difference between version numbers
2. Max/Min of rank values, the difference between rank values